### PR TITLE
教授のいいね機能の実装

### DIFF
--- a/src/js/modules/Like.js
+++ b/src/js/modules/Like.js
@@ -1,0 +1,69 @@
+import $ from 'jquery';
+
+class Like {
+  constructor(){
+    this.events();
+  }
+
+  events(){
+    $('.like-box').on('click', this.ourClickDispatcher.bind(this));
+  }
+
+  ourClickDispatcher(e){
+    let currentLikeBox = $(e.target).closest(".like-box");
+    if(currentLikeBox.data('exists') == 'yes') {
+      this.deleteLike(currentLikeBox);
+      currentLikeBox.data('exists', 'no');
+    } else {
+      this.createLike(currentLikeBox);
+      currentLikeBox.data('exists', 'yes');
+    }
+  }
+
+  createLike(likeBox){
+    console.log('create: ' + likeBox.data('professor-id'));
+    $.ajax({
+      beforeSend: (xhr) => {
+        xhr.setRequestHeader('X-WP-Nonce', universityData.nonce); // リクエストヘッダーに once を渡して認可
+      },
+      url: universityData.root_url + '/wp-json/univ/v1/manageLike/',
+      type: 'POST',
+      data: {
+        'professorId': likeBox.data('professor-id'),
+      },
+      success: (response) => {
+        console.log(response);
+        console.log('作成成功');
+      },
+      error: (response) => {
+        console.log(response);
+        console.log('作成失敗');
+      }
+    });
+  }
+  
+  deleteLike(likeBox){
+    $.ajax({
+      beforeSend: (xhr) => {
+        xhr.setRequestHeader('X-WP-Nonce', universityData.nonce); // リクエストヘッダーに once を渡して認可
+      },
+      url: universityData.root_url + '/wp-json/univ/v1/manageLike/',
+      type: 'DELETE',
+      data: {
+        'professorId': likeBox.data('professor-id'),
+      },
+      success: (response) => {
+        console.log(response);
+        console.log('削除成功');
+      },
+      error: (response) => {
+        console.log(response);
+        console.log('削除失敗');
+      }
+    });
+    
+  }
+
+}
+
+export default Like

--- a/src/js/modules/Like.js
+++ b/src/js/modules/Like.js
@@ -11,17 +11,16 @@ class Like {
 
   ourClickDispatcher(e){
     let currentLikeBox = $(e.target).closest(".like-box");
-    if(currentLikeBox.data('exists') == 'yes') {
+    // currentLikeBox.data('exists') の書き方だとページの読み込み時しか効かない
+    // リアルタイムのデータの更新なら attr を使う。
+    if(currentLikeBox.attr('data-exists') == 'yes') {
       this.deleteLike(currentLikeBox);
-      currentLikeBox.data('exists', 'no');
     } else {
       this.createLike(currentLikeBox);
-      currentLikeBox.data('exists', 'yes');
     }
   }
 
   createLike(likeBox){
-    console.log('create: ' + likeBox.data('professor-id'));
     $.ajax({
       beforeSend: (xhr) => {
         xhr.setRequestHeader('X-WP-Nonce', universityData.nonce); // リクエストヘッダーに once を渡して認可
@@ -33,11 +32,14 @@ class Like {
       },
       success: (response) => {
         console.log(response);
-        console.log('作成成功');
+
+        likeBox.attr('data-exists', 'yes');
+        let $likeCount = likeBox.find('.like-count')
+        let likeCountValue = parseInt($likeCount.text());
+        $likeCount.text(likeCountValue + 1);
       },
       error: (response) => {
         console.log(response);
-        console.log('作成失敗');
       }
     });
   }
@@ -54,11 +56,14 @@ class Like {
       },
       success: (response) => {
         console.log(response);
-        console.log('削除成功');
+
+        likeBox.attr('data-exists', 'no');
+        let $likeCount = likeBox.find('.like-count')
+        let likeCountValue = parseInt($likeCount.text());
+        $likeCount.text(likeCountValue - 1);
       },
       error: (response) => {
         console.log(response);
-        console.log('削除失敗');
       }
     });
     

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -8,6 +8,7 @@ import HeroSlider from './modules/HeroSlider';
 import GoogleMap from './modules/GoogleMap';
 import Search from './modules/Search';
 import MyNotes from './modules/MyNotes';
+import Like from './modules/Like';
 
 // // Instantiate a new object using our modules/classes
 const mobileMenu = new MobileMenu();
@@ -15,3 +16,4 @@ const heroSlider = new HeroSlider();
 const googleMap = new GoogleMap();
 const search = new Search();
 const myNotes = new MyNotes();
+const like = new Like();

--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 require get_theme_file_path('/libs/search-route.php');
+require get_theme_file_path('/libs/like-route.php');
 
 // css, js読み込み
 function university_files()
@@ -141,7 +142,7 @@ function my_post_types()
 			'all_items' => 'All Likes',
 			'singular_name' => 'like',
 		),
-		'supports' => array('title'),
+		'supports' => array('title', 'author'),
 		'menu_icon' => 'dashicons-heart',
 		'public'        => false,
 		'show_ui' => true,

--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -131,6 +131,21 @@ function my_post_types()
 		'capability_type' => 'note',
 		'map_meta_cap' => true,
 	));
+
+	// Like post type
+	register_post_type('like', array(
+		'labels' => array(
+			'name'          => '教授いいね',
+			'add_new_item' => 'Add New Like',
+			'edit_item' => 'Edit Like',
+			'all_items' => 'All Likes',
+			'singular_name' => 'like',
+		),
+		'supports' => array('title'),
+		'menu_icon' => 'dashicons-heart',
+		'public'        => false,
+		'show_ui' => true,
+	));
 }
 
 add_action('init', 'my_post_types');

--- a/src/php/libs/like-route.php
+++ b/src/php/libs/like-route.php
@@ -29,7 +29,7 @@ function create_like($data)
         )
       ),
     ));
-    if ($exist_query->have_posts == 0 and get_post_type($professor_id) == 'professor') {
+    if ($exist_query->found_posts == 0 and get_post_type($professor_id) == 'professor') {
       return wp_insert_post(array(
         'post_type' => 'like',
         'post_status' => 'publish',
@@ -65,7 +65,7 @@ function delete_like($data)
     if($exist_query->have_posts()){
       while($exist_query->have_posts()){
         $exist_query->the_post();
-        wp_delete_post(get_the_ID());
+        wp_delete_post(get_the_ID(), true);
       }
       wp_reset_postdata();
       return 'Your like deleted.';

--- a/src/php/libs/like-route.php
+++ b/src/php/libs/like-route.php
@@ -1,0 +1,81 @@
+<?php
+
+function professor_like_routes()
+{
+  register_rest_route('univ/v1', 'manageLike', array(
+    'methods' => 'POST',
+    'callback' => 'create_like',
+  ));
+
+  register_rest_route('univ/v1', 'manageLike', array(
+    'methods' => 'DELETE',
+    'callback' => 'delete_like',
+  ));
+}
+
+function create_like($data)
+{
+  if (is_user_logged_in()) { // roleに基づいて判定
+    $professor_id = sanitize_text_field($data['professorId']);
+
+    $exist_query = new WP_Query(array(
+      'author' => get_current_user_id(),
+      'post_type' => 'like',
+      'meta_query' => array(
+        array(
+          'key' => 'liked_professor_id',
+          'compare' => '=',
+          'value' => $professor_id,
+        )
+      ),
+    ));
+    if ($exist_query->have_posts == 0 and get_post_type($professor_id) == 'professor') {
+      return wp_insert_post(array(
+        'post_type' => 'like',
+        'post_status' => 'publish',
+        'post_title' => 'professor: ' . $professor_id,
+        'meta_input' => array(
+          'liked_professor_id' => $professor_id
+        ),
+      ));
+    } else {
+      die("いいね済み or 不正な Professor");
+    }
+  } else {
+    die("Only logged in uers can create a like.");
+  }
+}
+
+function delete_like($data)
+{
+  if (is_user_logged_in()) { // roleに基づいて判定
+    $professor_id = sanitize_text_field($data['professorId']);
+    $exist_query = new WP_Query(array(
+      'author' => get_current_user_id(),
+      'post_type' => 'like',
+      'meta_query' => array(
+        array(
+          'key' => 'liked_professor_id',
+          'compare' => '=',
+          'value' => $professor_id,
+        )
+      ),
+    ));
+
+    if($exist_query->have_posts()){
+      while($exist_query->have_posts()){
+        $exist_query->the_post();
+        wp_delete_post(get_the_ID());
+      }
+      wp_reset_postdata();
+      return 'Your like deleted.';
+    } else {
+      die("Invalid professor id.");
+    }
+
+  } else {
+    die("Only logged in users can delete a like.");
+  }
+}
+
+add_action('rest_api_init', 'professor_like_routes');

--- a/src/php/single-professor.php
+++ b/src/php/single-professor.php
@@ -11,6 +11,40 @@ while (have_posts()) {
                     <?php the_post_thumbnail('professor-portrait'); ?>
                 </div>
                 <div class="two-thirds">
+                    <?php 
+                        $like_count = new WP_Query(array(
+                            'post_type' => 'like',
+                            'meta_query' => array(
+                                array(
+                                    'key' => 'liked_professor_id',
+                                    'compare' => '=',
+                                    'value' => get_the_ID(),
+                                )
+                            ),
+                        ));
+
+                        $exist_status = 'no';
+                        $exist_query = new WP_Query(array(
+                            'author' => get_current_user_id(),
+                            'post_type' => 'like',
+                            'meta_query' => array(
+                                array(
+                                    'key' => 'liked_professor_id',
+                                    'compare' => '=',
+                                    'value' => get_the_ID(),
+                                )
+                            ),
+                        ));
+                        if($exist_query->found_posts){
+                            $exist_status = 'yes';
+                        }
+                    ?>
+
+                    <span class="like-box" data-exists="<?php echo $exist_status; ?>">
+                        <i class="fa fa-heart-o" aria-hidden="true"></i>
+                        <i class="fa fa-heart" aria-hidden="true"></i>
+                        <span class="like-count"><?php echo $like_count->found_posts; ?></span>
+                    </span>
                     <?php the_content(); ?>
                 </div>
             </div>

--- a/src/php/single-professor.php
+++ b/src/php/single-professor.php
@@ -11,19 +11,23 @@ while (have_posts()) {
                     <?php the_post_thumbnail('professor-portrait'); ?>
                 </div>
                 <div class="two-thirds">
-                    <?php 
-                        $like_count = new WP_Query(array(
-                            'post_type' => 'like',
-                            'meta_query' => array(
-                                array(
-                                    'key' => 'liked_professor_id',
-                                    'compare' => '=',
-                                    'value' => get_the_ID(),
-                                )
-                            ),
-                        ));
+                    <?php
+                    $like_count = new WP_Query(array(
+                        'post_type' => 'like',
+                        'meta_query' => array(
+                            array(
+                                'key' => 'liked_professor_id',
+                                'compare' => '=',
+                                'value' => get_the_ID(),
+                            )
+                        ),
+                    ));
 
-                        $exist_status = 'no';
+                    $exist_status = 'no';
+
+                    // 'author' => 0,
+                    // を指定するとAll authorを意味してしまうのでクエリをログイン時に限定
+                    if (is_user_logged_in()) {
                         $exist_query = new WP_Query(array(
                             'author' => get_current_user_id(),
                             'post_type' => 'like',
@@ -35,12 +39,13 @@ while (have_posts()) {
                                 )
                             ),
                         ));
-                        if($exist_query->found_posts){
+                        if ($exist_query->found_posts) {
                             $exist_status = 'yes';
                         }
+                    }
                     ?>
 
-                    <span class="like-box" data-exists="<?php echo $exist_status; ?>">
+                    <span class="like-box" data-exists="<?php echo $exist_status; ?>" data-professor-id="<?php the_ID(); ?>">
                         <i class="fa fa-heart-o" aria-hidden="true"></i>
                         <i class="fa fa-heart" aria-hidden="true"></i>
                         <span class="like-count"><?php echo $like_count->found_posts; ?></span>
@@ -49,6 +54,9 @@ while (have_posts()) {
                 </div>
             </div>
         </div>
+
+        user_id
+        <?php echo get_current_user_id(); ?>
 
         <?php $related_programs = get_field('related_programs'); ?>
         <?php if ($related_programs) : ?>


### PR DESCRIPTION
# 内容
- Like post type を作成
  - custom field に liked_professor_id を作成しておく
  - 単純なCRUDではないので`show_in_rest`を不許可にした
  - user - professorへのいいねは重複を許さない
  - nonceでcreate, deleteを認可（ないとログインしている判定もバグる）
  - いいねを押すと、リアルタイムにいいねの数が増減するJQueryを記述

## 学習したこと
- JQueryの.`data('xxx')`はページ読み込み時に使うのはよいが、リアルタイム読み書きに向かないので`attr('data-xxx')`を使う
- `WP REST APIで nonce`を使ってCRUDの認可を行う